### PR TITLE
Fix for odim-87-subtask1: Session Creation in plugin giving 404

### DIFF
--- a/plugin-redfish/main.go
+++ b/plugin-redfish/main.go
@@ -99,7 +99,7 @@ func routers() *iris.Application {
 	pluginRoutes := app.Party("/ODIM/v1")
 	{
 		pluginRoutes.Post("/validate", rfpmiddleware.BasicAuth, rfphandler.Validate)
-		pluginRoutes.Post("/Session", rfphandler.CreateSession)
+		pluginRoutes.Post("/Sessions", rfphandler.CreateSession)
 		pluginRoutes.Post("/Subscriptions", rfpmiddleware.BasicAuth, rfphandler.CreateEventSubscription)
 		pluginRoutes.Delete("/Subscriptions", rfpmiddleware.BasicAuth, rfphandler.DeleteEventSubscription)
 


### PR DESCRIPTION
While adding GRF plugin with PrefferedAuthType as XAuthToken, getting 404 error because of the wrong endpoint exposed by plugin /ODIM/v1/Session instead of /ODIM/v1/Sessions