### PR TITLE
odim-98: Get response on session service gives 401 status code error with invalid basic authentication

### DIFF
--- a/svc-api/main.go
+++ b/svc-api/main.go
@@ -48,6 +48,21 @@ func main() {
 		}
 		basicAuth := r.Header.Get("Authorization")
 		var basicAuthToken string
+		// This if block added to fix issue odim-98
+		if basicAuth != "" {
+			var URLs_not_requiring_basic_auth = []string {"/redfish/v1","/redfish/v1/SessionService"}
+			var found bool = false
+			for _, item := range URLs_not_requiring_basic_auth {
+				if item == path {
+					found = true
+					break
+				}
+			}
+			if found {
+				log.Println("warning: basic auth is provided but not used as URL is: "+path)
+				basicAuth = ""
+			}
+		}
 		if basicAuth != "" {
 			var username, password string
 			yes := strings.Contains(basicAuth, "Basic")

--- a/svc-api/main.go
+++ b/svc-api/main.go
@@ -48,83 +48,79 @@ func main() {
 		}
 		basicAuth := r.Header.Get("Authorization")
 		var basicAuthToken string
-		// This if block added to fix issue odim-98
 		if basicAuth != "" {
-			var URLs_not_requiring_basic_auth = []string {"/redfish/v1","/redfish/v1/SessionService"}
-			var found bool = false
-			for _, item := range URLs_not_requiring_basic_auth {
+			var urlNoBasicAuth = []string {"/redfish/v1","/redfish/v1/SessionService"}
+			var authRequired bool = true
+			for _, item := range urlNoBasicAuth {
 				if item == path {
-					found = true
+					authRequired = false
+					log.Println("warning: basic auth is provided but not used as URL is: "+path)
 					break
 				}
 			}
-			if found {
-				log.Println("warning: basic auth is provided but not used as URL is: "+path)
-				basicAuth = ""
-			}
-		}
-		if basicAuth != "" {
-			var username, password string
-			yes := strings.Contains(basicAuth, "Basic")
-			if yes {
-				spl := strings.Split(basicAuth, " ")
-				data, err := base64.StdEncoding.DecodeString(spl[1])
-				if err != nil {
-					log.Println("error:", err)
-					return
-				}
-				userCred := strings.SplitN(string(data), ":", 2)
-				if len(userCred) < 2 {
+			if authRequired {
+				var username, password string
+				yes := strings.Contains(basicAuth, "Basic")
+				if yes {
+					spl := strings.Split(basicAuth, " ")
+					data, err := base64.StdEncoding.DecodeString(spl[1])
+					if err != nil {
+						log.Println("error:", err)
+						return
+					}
+					userCred := strings.SplitN(string(data), ":", 2)
+					if len(userCred) < 2 {
+						log.Println("error: not a valid basic auth")
+						return
+					}
+					username = userCred[0]
+					password = userCred[1]
+				} else {
 					log.Println("error: not a valid basic auth")
 					return
 				}
-				username = userCred[0]
-				password = userCred[1]
-			} else {
-				log.Println("error: not a valid basic auth")
-				return
-			}
 
-			//Converting the request into a map
-			sessionReq := map[string]interface{}{
-				"UserName": username,
-				"Password": password,
-			}
-			//Marshalling input to get bytes since session create request accepts bytes
-			sessionReqData, err := json.Marshal(sessionReq)
+				//Converting the request into a map
+				sessionReq := map[string]interface{}{
+					"UserName": username,
+					"Password": password,
+				}
+				//Marshalling input to get bytes since session create request accepts bytes
+				sessionReqData, err := json.Marshal(sessionReq)
 
-			var req sessionproto.SessionCreateRequest
-			req.RequestBody = sessionReqData
-			resp, err := rpc.DoSessionCreationRequest(req)
-			if err != nil && resp == nil {
-				errorMessage := "error: something went wrong with the RPC calls: " + err.Error()
-				log.Println(errorMessage)
-				w.Header().Set("Content-type", "application/json; charset=utf-8")
-				w.WriteHeader(http.StatusInternalServerError)
-				body, _ := json.Marshal(common.GeneralError(http.StatusInternalServerError, response.InternalError, errorMessage, nil, nil).Body)
-				w.Write([]byte(body))
-				return
-			}
-			if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-				errorMessage := "error: failed to create a sesssion"
-				log.Println(errorMessage)
-				w.Header().Set("Content-type", "application/json; charset=utf-8")
-				w.WriteHeader(int(resp.StatusCode))
-				body, _ := json.Marshal(common.GeneralError(resp.StatusCode, resp.StatusMessage, errorMessage, nil, nil).Body)
-				w.Write([]byte(body))
-				return
-			}
-			var sessionHeader map[string]string
-			var sessionID string
-			sessionHeader = resp.Header
-			basicAuthToken = sessionHeader["X-Auth-Token"]
-			sessionLocation := sessionHeader["Link"]
-			sessionLocationSlice := strings.Split(sessionLocation, "/")
-			if len(sessionLocationSlice) > 1 {
-				sessionID = sessionLocationSlice[len(sessionLocationSlice)-2]
-			}
-			r.Header.Set("X-Auth-Token", basicAuthToken)
-			r.Header.Set("Session-ID", sessionID)
+				var req sessionproto.SessionCreateRequest
+				req.RequestBody = sessionReqData
+				resp, err := rpc.DoSessionCreationRequest(req)
+				if err != nil && resp == nil {
+					errorMessage := "error: something went wrong with the RPC calls: " + err.Error()
+					log.Println(errorMessage)
+					w.Header().Set("Content-type", "application/json; charset=utf-8")
+					w.WriteHeader(http.StatusInternalServerError)
+					body, _ := json.Marshal(common.GeneralError(http.StatusInternalServerError, response.InternalError, errorMessage, nil, nil).Body)
+					w.Write([]byte(body))
+					return
+				}
+				if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+					errorMessage := "error: failed to create a sesssion"
+					log.Println(errorMessage)
+					w.Header().Set("Content-type", "application/json; charset=utf-8")
+					w.WriteHeader(int(resp.StatusCode))
+					body, _ := json.Marshal(common.GeneralError(resp.StatusCode, resp.StatusMessage, errorMessage, nil, nil).Body)
+					w.Write([]byte(body))
+					return
+				}
+				var sessionHeader map[string]string
+				var sessionID string
+				sessionHeader = resp.Header
+				basicAuthToken = sessionHeader["X-Auth-Token"]
+				sessionLocation := sessionHeader["Link"]
+				sessionLocationSlice := strings.Split(sessionLocation, "/")
+				if len(sessionLocationSlice) > 1 {
+					sessionID = sessionLocationSlice[len(sessionLocationSlice)-2]
+				}
+				r.Header.Set("X-Auth-Token", basicAuthToken)
+				r.Header.Set("Session-ID", sessionID)
+			} 
 		}
 		// r.URL.Path = strings.ToLower(path)
 		next(w, r)

--- a/svc-api/router/router.go
+++ b/svc-api/router/router.go
@@ -162,7 +162,7 @@ func Router() *iris.Application {
 
 	session := v1.Party("/SessionService")
 	session.SetRegisterRule(iris.RouteSkip)
-	session.Get("/", middleware.SessionDelMiddleware, s.GetSessionService)
+	session.Get("/", s.GetSessionService)
 	session.Get("/Sessions", middleware.SessionDelMiddleware, s.GetAllActiveSessions)
 	session.Get("/Sessions/{sessionID}", middleware.SessionDelMiddleware, s.GetSession)
 	session.Post("/Sessions", s.CreateSession)


### PR DESCRIPTION
Issue:

1.Execute Get operation on  the session service with invalid basic authentication   ,It gives 401 unauthorized error

GET API: https://<odimra ip>:45000/redfish/v1/SessionService

Basic authentication: admin01/HP!nvent01

2. Expected Result: It should execute with 200 status code

Developer Note:
1) Fixed for URL /redfish/v1 as well as it is a common issue impacting URLs which do not need basic auth
2) Please enable "Hide Whitespace change" while checking the difference as a huge chunk of code had to be included in a new if condition.